### PR TITLE
Added option to not apply env in Test run configurations

### DIFF
--- a/src/main/kotlin/com/bredogen/projectenv/extensions/GoRunConfigurationExtension.kt
+++ b/src/main/kotlin/com/bredogen/projectenv/extensions/GoRunConfigurationExtension.kt
@@ -4,17 +4,29 @@ import com.bredogen.projectenv.services.ProjectEnvService
 import com.goide.execution.GoRunConfigurationBase
 import com.goide.execution.GoRunningState
 import com.goide.execution.extension.GoRunConfigurationExtension
+import com.goide.execution.testing.GoTestRunConfiguration
+import com.intellij.execution.configurations.RunConfigurationBase
 import com.intellij.execution.configurations.RunnerSettings
 import com.intellij.execution.target.TargetedCommandLineBuilder
 
 class GoRunConfigurationExtension : GoRunConfigurationExtension() {
     override fun isApplicableFor(configuration: GoRunConfigurationBase<*>): Boolean = true
     override fun isEnabledFor(applicableConfiguration: GoRunConfigurationBase<*>, runnerSettings: RunnerSettings?): Boolean {
-        return ProjectEnvService.getInstance(applicableConfiguration.getProject()).enableRunConfiguration
+        val projectEnvService = ProjectEnvService.getInstance(applicableConfiguration.getProject())
+
+        if (!projectEnvService.includeTestConfiguration && isTestConfiguration(applicableConfiguration)) {
+            return false
+        }
+
+        return projectEnvService.enableRunConfiguration
+    }
+
+    private fun isTestConfiguration(applicableConfiguration: RunConfigurationBase<*>): Boolean {
+        return applicableConfiguration is GoTestRunConfiguration
     }
 
     override fun patchCommandLine(configuration: GoRunConfigurationBase<*>, runnerSettings: RunnerSettings?, cmdLine: TargetedCommandLineBuilder, runnerId: String, state: GoRunningState<out GoRunConfigurationBase<*>>, commandLineType: GoRunningState.CommandLineType) {
         val envService = ProjectEnvService.getInstance(configuration.getProject())
-        envService.getEnvValues().forEach {env -> cmdLine.addEnvironmentVariable(env.key, env.value)}
+        envService.getEnvValues().forEach { env -> cmdLine.addEnvironmentVariable(env.key, env.value) }
     }
 }

--- a/src/main/kotlin/com/bredogen/projectenv/extensions/JavaRunConfigurationExtension.kt
+++ b/src/main/kotlin/com/bredogen/projectenv/extensions/JavaRunConfigurationExtension.kt
@@ -1,16 +1,30 @@
 package com.bredogen.projectenv.extensions
 
 import com.bredogen.projectenv.services.ProjectEnvService
+import com.intellij.execution.JavaTestConfigurationBase
 import com.intellij.execution.RunConfigurationExtension
 import com.intellij.execution.configurations.JavaParameters
 import com.intellij.execution.configurations.RunConfigurationBase
 import com.intellij.execution.configurations.RunnerSettings
+import com.jetbrains.python.testing.PyAbstractTestConfiguration
+import com.jetbrains.python.testing.PyTestConfiguration
+import com.jetbrains.python.testing.PythonTestConfigurationType
 
 class JavaRunConfigurationExtension : RunConfigurationExtension() {
     override fun isApplicableFor(configuration: RunConfigurationBase<*>): Boolean = true
 
     override fun isEnabledFor(applicableConfiguration: RunConfigurationBase<*>, runnerSettings: RunnerSettings?): Boolean {
-        return ProjectEnvService.getInstance(applicableConfiguration.project).enableRunConfiguration
+        val projectEnvService = ProjectEnvService.getInstance(applicableConfiguration.project)
+
+        if (!projectEnvService.includeTestConfiguration && isTestConfiguration(applicableConfiguration)) {
+            return false
+        }
+
+        return projectEnvService.enableRunConfiguration
+    }
+
+    private fun isTestConfiguration(applicableConfiguration: RunConfigurationBase<*>): Boolean {
+        return applicableConfiguration is JavaTestConfigurationBase
     }
 
     override fun <T : RunConfigurationBase<*>> updateJavaParameters(configuration: T, params: JavaParameters, runnerSettings: RunnerSettings?) {

--- a/src/main/kotlin/com/bredogen/projectenv/extensions/PythonConsoleExtension.kt
+++ b/src/main/kotlin/com/bredogen/projectenv/extensions/PythonConsoleExtension.kt
@@ -4,6 +4,7 @@ import com.bredogen.projectenv.services.ProjectEnvService
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.SdkAdditionalData
+import com.jetbrains.python.console.PydevConsoleRunnerImpl
 import com.jetbrains.python.run.PythonCommandLineEnvironmentProvider
 import com.jetbrains.python.run.PythonRunParams
 
@@ -14,6 +15,10 @@ class PythonConsoleExtension : PythonCommandLineEnvironmentProvider {
             cmdLine: GeneralCommandLine,
             runParams: PythonRunParams?
     ) {
+        if (runParams !is PydevConsoleRunnerImpl.PythonConsoleRunParams) {
+            return
+        }
+
         val envService = ProjectEnvService.getInstance(project)
         if (envService.enableTerminal) {
             cmdLine.environment.putAll(envService.getEnvValues())

--- a/src/main/kotlin/com/bredogen/projectenv/extensions/PythonRunConfigurationExtension.kt
+++ b/src/main/kotlin/com/bredogen/projectenv/extensions/PythonRunConfigurationExtension.kt
@@ -2,14 +2,26 @@ package com.bredogen.projectenv.extensions
 
 import com.bredogen.projectenv.services.ProjectEnvService
 import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.configurations.RunConfigurationBase
 import com.intellij.execution.configurations.RunnerSettings
 import com.jetbrains.python.run.AbstractPythonRunConfiguration
 import com.jetbrains.python.run.PythonRunConfigurationExtension
+import com.jetbrains.python.testing.PyAbstractTestConfiguration
 
 class PythonRunConfigurationExtension : PythonRunConfigurationExtension() {
     override fun isApplicableFor(configuration: AbstractPythonRunConfiguration<*>): Boolean = true
     override fun isEnabledFor(applicableConfiguration: AbstractPythonRunConfiguration<*>, runnerSettings: RunnerSettings?): Boolean {
-        return ProjectEnvService.getInstance(applicableConfiguration.project).enableRunConfiguration
+        val projectEnvService = ProjectEnvService.getInstance(applicableConfiguration.project)
+
+        if (!projectEnvService.includeTestConfiguration && isTestConfiguration(applicableConfiguration)) {
+            return false
+        }
+
+        return projectEnvService.enableRunConfiguration
+    }
+
+    private fun isTestConfiguration(applicableConfiguration: RunConfigurationBase<*>): Boolean {
+        return applicableConfiguration is PyAbstractTestConfiguration
     }
 
     override fun patchCommandLine(configuration: AbstractPythonRunConfiguration<*>, runnerSettings: RunnerSettings?, cmdLine: GeneralCommandLine, runnerId: String) {

--- a/src/main/kotlin/com/bredogen/projectenv/services/ProjectEnvService.kt
+++ b/src/main/kotlin/com/bredogen/projectenv/services/ProjectEnvService.kt
@@ -15,6 +15,7 @@ class ProjectEnvService : PersistentStateComponent<ProjectEnvService>, BaseState
 
     var enableTerminal by property(true)
     var enableRunConfiguration by property(true)
+    var includeTestConfiguration by property(true)
 
     override fun getState(): ProjectEnvService {
         return this

--- a/src/main/kotlin/com/bredogen/projectenv/ui/WindowFactory.kt
+++ b/src/main/kotlin/com/bredogen/projectenv/ui/WindowFactory.kt
@@ -1,5 +1,6 @@
 package com.bredogen.projectenv.ui
 
+import com.bredogen.projectenv.ui.actions.EnvEnableInTestConfigurationToggleAction
 import com.bredogen.projectenv.ui.actions.EnvRunConfigurationToggleAction
 import com.bredogen.projectenv.ui.actions.EnvTerminalToggleAction
 import com.intellij.openapi.actionSystem.DefaultActionGroup
@@ -19,7 +20,8 @@ class WindowFactory : ToolWindowFactory, DumbAware {
         if (toolWindow is ToolWindowEx) {
             toolWindow.setAdditionalGearActions(DefaultActionGroup(listOf(
                     EnvTerminalToggleAction(),
-                    EnvRunConfigurationToggleAction()
+                    EnvRunConfigurationToggleAction(),
+                    EnvEnableInTestConfigurationToggleAction(),
             )))
         }
     }

--- a/src/main/kotlin/com/bredogen/projectenv/ui/actions/EnvEnableInTestConfigurationToggleAction.kt
+++ b/src/main/kotlin/com/bredogen/projectenv/ui/actions/EnvEnableInTestConfigurationToggleAction.kt
@@ -1,0 +1,16 @@
+package com.bredogen.projectenv.ui.actions
+
+import com.bredogen.projectenv.services.ProjectEnvService
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareToggleAction
+
+internal class EnvEnableInTestConfigurationToggleAction : DumbAwareToggleAction("Enable Also in Test Run Configurations") {
+
+    override fun isSelected(event: AnActionEvent) = event.project?.let { ProjectEnvService.getInstance(it).includeTestConfiguration } ?: true
+
+    override fun setSelected(event: AnActionEvent, isSelected: Boolean) {
+        event.project?.let {
+            ProjectEnvService.getInstance(it).includeTestConfiguration = isSelected
+        }
+    }
+}

--- a/src/main/kotlin/com/bredogen/projectenv/ui/actions/EnvRunConfigurationToggleAction.kt
+++ b/src/main/kotlin/com/bredogen/projectenv/ui/actions/EnvRunConfigurationToggleAction.kt
@@ -10,7 +10,7 @@ internal class EnvRunConfigurationToggleAction : DumbAwareToggleAction("Enable i
 
     override fun setSelected(event: AnActionEvent, isSelected: Boolean) {
         event.project?.let {
-            ProjectEnvService.getInstance(it).enableTerminal = isSelected
+            ProjectEnvService.getInstance(it).enableRunConfiguration = isSelected
         }
     }
 }

--- a/src/main/resources/META-INF/projectenv-pycharm.xml
+++ b/src/main/resources/META-INF/projectenv-pycharm.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
     <extensions defaultExtensionNs="Pythonid">
         <runConfigurationExtension implementation="com.bredogen.projectenv.extensions.PythonRunConfigurationExtension" id="envfilePython"/>
-        <pythonCommandLineEnvironmentProvider implementation="com.bredogen.projectenv.extensions.PythonConsoleExtension" id="envfilePytohnConsole"/>
+        <pythonCommandLineEnvironmentProvider implementation="com.bredogen.projectenv.extensions.PythonConsoleExtension" id="envfilePythonConsole"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Couldn't test it well cause the current version of the plugin has the ui broken
would be happy to update once refactor is done, or feel free to edit this PR :)
The motivation is that many times env vars are for runtime specific stuff and tests define their own mock beans etc. If these mocks then get overridden by env vars, its usually not what you intended :)