### PR TITLE
Bump versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,9 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.6.10"
+    id("org.jetbrains.kotlin.jvm") version "1.6.21"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.4.0"
+    id("org.jetbrains.intellij") version "1.9.0"
     // Gradle Changelog Plugin
     id("org.jetbrains.changelog") version "1.3.1"
     // Gradle Qodana Plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,23 +4,23 @@
 pluginGroup = com.bredogen.projectenv
 pluginName = ProjectEnv
 # SemVer format -> https://semver.org
-pluginVersion = 0.1.0
+pluginVersion = 0.2.0
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 203
-pluginUntilBuild = 221.*
+pluginSinceBuild = 221.*
+pluginUntilBuild = 222.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IU
-platformVersion = 2021.3.3
+platformVersion = 2022.2.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = terminal, com.intellij.java, Pythonid:213.7172.26, org.jetbrains.plugins.go:213.7172.6
+platformPlugins = terminal, com.intellij.java, Pythonid:222.4345.14, org.jetbrains.plugins.go:222.4345.14
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
-javaVersion = 11
+javaVersion = 17
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 7.4


### PR DESCRIPTION
Not sure if I went about this correctly or not; my goal was to get the plugin to work in PyCharm 2022.2.3 and I seem to have succeeded; but I think I may have broken backward compatibility for earlier ide versions...